### PR TITLE
fix: prevent error when pasting more characters than input boxes

### DIFF
--- a/projects/ngx-otp-input/src/lib/ngx-otp-input.component.ts
+++ b/projects/ngx-otp-input/src/lib/ngx-otp-input.component.ts
@@ -130,7 +130,7 @@ export class NgxOtpInputComponent implements OnInit, OnChanges {
       this.ngxOtpInputArray.setValue($event);
     } else {
       $event.map((value, index) => {
-        this.ngxOtpInputArray.controls[index].setValue(value);
+        this.ngxOtpInputArray.controls[index]?.setValue?.(value);
       });
     }
     this.emitOtpValueChange();


### PR DESCRIPTION
**fix: prevent error when pasting more characters than input boxes**  

- Use optional chaining to avoid accessing `setValue` on undefined controls.  
- Updated code to safely handle cases where pasted input exceeds available input boxes.

issue #31