### PR TITLE
Changed backspace behaviour to remove the last input when focus is on an empty input

### DIFF
--- a/projects/ngx-otp-input/src/lib/directives/inputNavigations.directive.ts
+++ b/projects/ngx-otp-input/src/lib/directives/inputNavigations.directive.ts
@@ -63,7 +63,10 @@ export class InputNavigationsDirective implements AfterContentInit {
   onBackspace(event: KeyboardEvent): void {
     const index = this.findInputIndex(event.target as HTMLElement);
     if (index >= 0) {
-      this.valueChange.emit([index, '']);
+      const indexToChange = this.inputsArray[index].nativeElement.value === ''
+        ? index - 1
+        : index;
+      this.valueChange.emit([indexToChange, '']);
       this.setFocus(index - 1);
       event.preventDefault();
     }


### PR DESCRIPTION
When you are focused on an empty input and press backspace, the focus changes to one index lower, but that input value is not removed. Then when you type a new value, nothing happens.
This change makes it so that when you press backspace on an empty input field, the last value is removed.